### PR TITLE
Change to hook smgrextend so that we could check the quota whenever a relation file is extended, for any command

### DIFF
--- a/enforcement.c
+++ b/enforcement.c
@@ -81,9 +81,8 @@ quota_check_SmgrExtend(SMgrRelation reln, ForkNumber forknum, BlockNumber blockn
 		 * We
 		 */
 		ereport(ERROR,
-			(errcode_for_file_access(),
-			errmsg("could not extend file"),
-			errhint("Check free disk space.")));
+				(errcode(ERRCODE_DISK_FULL),
+				errmsg("user's disk space quota exceeded")));
 	}
 
 	return;


### PR DESCRIPTION
This commit is one of TODOs as heikki referred.

See below.

> The disk_quota module hooks into the ExecutorCheckPerms_hook, which gets executed whenever an INSERT or COPY operation starts. If the table owner's quota has been exceeded, you get an error.
> 
> There are some limitations to this approach:
> 
> The quota is only checked at the beginning of the statement. If you have a quota of 1 GB, and use COPY to load 10 GB of data, it will succeed as long as you are below the quota at the beginning of the operation.
> 
> The quota is not enforced at UPDATEs, or utility commands like CREATE INDEX. (If an UPDATE or CREATE INDEX exceeds the quota, any subsequent INSERTs or COPYs will fail, though.)
> 
> TODO: It would be nice to have a hook directly in smgrextend() or similar lower level function, so that we could check the quota whenever a relation file is extended, for any command.